### PR TITLE
OniPatch: Fix & Refactoring

### DIFF
--- a/src/OniPatch/MyIDirect3D9.cpp
+++ b/src/OniPatch/MyIDirect3D9.cpp
@@ -1,0 +1,140 @@
+#include "pch.h"
+#include "MyIDirect3D9.h"
+
+MyIDirect3D9::MyIDirect3D9(IDirect3D9 *original)
+{
+    this->original = original;
+
+    this->Version = this->original->Version;
+}
+
+MyIDirect3D9::~MyIDirect3D9() {}
+
+/*** IUnknown methods ***/
+HRESULT MyIDirect3D9::QueryInterface(THIS_ REFIID riid, void **ppvObj)
+{
+    return this->original->QueryInterface(riid, ppvObj);
+}
+
+ULONG MyIDirect3D9::AddRef(THIS)
+{
+    return this->original->AddRef();
+}
+
+ULONG MyIDirect3D9::Release(THIS)
+{
+    return this->original->Release();
+}
+
+/*** IDirect3D9 methods ***/
+HRESULT MyIDirect3D9::RegisterSoftwareDevice(THIS_ void *pInitializeFunction)
+{
+    return this->original->RegisterSoftwareDevice(pInitializeFunction);
+}
+
+UINT MyIDirect3D9::GetAdapterCount(THIS)
+{
+    return this->original->GetAdapterCount();
+}
+
+HRESULT MyIDirect3D9::GetAdapterIdentifier(THIS_ UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER9 *pIdentifier)
+{
+    return this->original->GetAdapterIdentifier(Adapter, Flags, pIdentifier);
+}
+
+UINT MyIDirect3D9::GetAdapterModeCount(THIS_ UINT Adapter, D3DFORMAT Format)
+{
+    TraceFunc();
+    TraceParam("Adapter", Adapter);
+    TraceParam("D3DFORMAT", Format);
+
+    return this->original->GetAdapterModeCount(Adapter, Format);
+}
+
+HRESULT MyIDirect3D9::EnumAdapterModes(THIS_ UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE *pMode)
+{
+    TraceFunc();
+
+    TraceParam("Adapter", Adapter);
+    TraceParam("D3DFORMAT", Format);
+    TraceParam("Mode", Mode);
+    TraceParam("pMode ADDR", pMode);
+    TraceParam("d3dDisplayMode Width", pMode->Width);
+    TraceParam("d3dDisplayMode Height", pMode->Height);
+    TraceParam("d3dDisplayMode Refresh", pMode->RefreshRate);
+
+    return this->original->EnumAdapterModes(Adapter, Format, Mode, pMode);
+}
+
+HRESULT MyIDirect3D9::GetAdapterDisplayMode(THIS_ UINT Adapter, D3DDISPLAYMODE *pMode)
+{
+    return this->original->GetAdapterDisplayMode(Adapter, pMode);
+}
+
+HRESULT MyIDirect3D9::CheckDeviceType(THIS_ UINT iAdapter, D3DDEVTYPE DevType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed)
+{
+    return this->original->CheckDeviceType(iAdapter, DevType, DisplayFormat, BackBufferFormat, bWindowed);
+}
+
+HRESULT MyIDirect3D9::CheckDeviceFormat(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat)
+{
+    return this->original->CheckDeviceFormat(Adapter, DeviceType, AdapterFormat, Usage, RType, CheckFormat);
+}
+
+HRESULT MyIDirect3D9::CheckDeviceMultiSampleType(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType, DWORD *pQualityLevels)
+{
+    return this->original->CheckDeviceMultiSampleType(Adapter, DeviceType, SurfaceFormat, Windowed, MultiSampleType, pQualityLevels);
+}
+
+HRESULT MyIDirect3D9::CheckDepthStencilMatch(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat)
+{
+    return this->original->CheckDepthStencilMatch(Adapter, DeviceType, AdapterFormat, RenderTargetFormat, DepthStencilFormat);
+}
+
+HRESULT MyIDirect3D9::CheckDeviceFormatConversion(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SourceFormat, D3DFORMAT TargetFormat)
+{
+    return this->original->CheckDeviceFormatConversion(Adapter, DeviceType, SourceFormat, TargetFormat);
+}
+
+HRESULT MyIDirect3D9::GetDeviceCaps(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS9 *pCaps)
+{
+    return this->original->GetDeviceCaps(Adapter, DeviceType, pCaps);
+}
+
+HMONITOR MyIDirect3D9::GetAdapterMonitor(THIS_ UINT Adapter)
+{
+    return this->original->GetAdapterMonitor(Adapter);
+}
+
+HRESULT MyIDirect3D9::CreateDevice(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DDevice9 **ppReturnedDeviceInterface)
+{
+    TraceFunc();
+
+    TraceParam("BackBufferWidth", pPresentationParameters->BackBufferWidth);
+    TraceParam("BackBufferHeight", pPresentationParameters->BackBufferHeight);
+    TraceParam("Windowed", pPresentationParameters->Windowed);
+    TraceParam("MultiSampleType", pPresentationParameters->MultiSampleType);
+    TraceParam("MultiSampleQuality", pPresentationParameters->MultiSampleQuality);
+    TraceParam("SwapEffect", pPresentationParameters->SwapEffect);
+    TraceParam("AutoDepthStencilFormat", pPresentationParameters->AutoDepthStencilFormat);
+    TraceParam("PresentationInterval", pPresentationParameters->PresentationInterval);
+
+    if (pPresentationParameters->BackBufferWidth == 800) {
+
+        TraceMsg("Back buffer updated");
+
+        // TODO: Read this from configuration
+        pPresentationParameters->BackBufferWidth = 1920;
+        pPresentationParameters->BackBufferHeight = 1080;
+
+        //pPresentationParameters->Windowed = FALSE;
+    }
+
+    IDirect3DDevice9 *trueDevice = nullptr;
+
+    HRESULT hResult = this->original->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, pPresentationParameters, &trueDevice);
+
+    (*ppReturnedDeviceInterface) = new MyIDirect3DDevice9(trueDevice);
+
+    return hResult;
+}

--- a/src/OniPatch/MyIDirect3D9.h
+++ b/src/OniPatch/MyIDirect3D9.h
@@ -1,125 +1,39 @@
 #pragma once
 
-#include <d3d9helper.h>
-#include "Trace.h"
+#include "pch.h"
 #include "MyIDirect3DDevice9.h"
+#include "Trace.h"
 
 class MyIDirect3D9 : public IDirect3D9
 {
 private:
-	IDirect3D9* original;
+    IDirect3D9 *original;
 public:
-	MyIDirect3D9(IDirect3D9* original) {
-		this->original = original;
-		this->Version = this->original->Version;
-	}
+    MyIDirect3D9(IDirect3D9 *original);
+    virtual ~MyIDirect3D9();
 
-	virtual ~MyIDirect3D9() {
+    /*** IUnknown methods ***/
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void **ppvObj);
+    STDMETHOD_(ULONG, AddRef)(THIS);
+    STDMETHOD_(ULONG, Release)(THIS);
 
-	}
+    /*** IDirect3D9 methods ***/
+    STDMETHOD(RegisterSoftwareDevice)(THIS_ void *pInitializeFunction);
+    STDMETHOD_(UINT, GetAdapterCount)(THIS);
+    STDMETHOD(GetAdapterIdentifier)(THIS_ UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER9 *pIdentifier);
+    STDMETHOD_(UINT, GetAdapterModeCount)(THIS_ UINT Adapter, D3DFORMAT Format);
+    STDMETHOD(EnumAdapterModes)(THIS_ UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE *pMode);
+    STDMETHOD(GetAdapterDisplayMode)(THIS_ UINT Adapter, D3DDISPLAYMODE *pMode);
+    STDMETHOD(CheckDeviceType)(THIS_ UINT iAdapter, D3DDEVTYPE DevType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed);
+    STDMETHOD(CheckDeviceFormat)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat);
+    STDMETHOD(CheckDeviceMultiSampleType)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType, DWORD *pQualityLevels);
+    STDMETHOD(CheckDepthStencilMatch)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat);
+    STDMETHOD(CheckDeviceFormatConversion)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SourceFormat, D3DFORMAT TargetFormat);
+    STDMETHOD(GetDeviceCaps)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS9 *pCaps);
+    STDMETHOD_(HMONITOR, GetAdapterMonitor)(THIS_ UINT Adapter);
+    STDMETHOD(CreateDevice)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DDevice9 **ppReturnedDeviceInterface);
 
-	/*** IUnknown methods ***/
-	STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) {
-		return this->original->QueryInterface(riid, ppvObj);
-	}
-
-	STDMETHOD_(ULONG, AddRef)(THIS) {
-		return this->original->AddRef();
-	}
-
-	STDMETHOD_(ULONG, Release)(THIS) {
-		return this->original->Release();
-	}
-
-	/*** IDirect3D9 methods ***/
-	STDMETHOD(RegisterSoftwareDevice)(THIS_ void* pInitializeFunction) {
-		return this->original->RegisterSoftwareDevice(pInitializeFunction);
-	}
-
-	STDMETHOD_(UINT, GetAdapterCount)(THIS) {
-		return this->original->GetAdapterCount();
-	}
-
-	STDMETHOD(GetAdapterIdentifier)(THIS_ UINT Adapter, DWORD Flags, D3DADAPTER_IDENTIFIER9* pIdentifier) {
-		return this->original->GetAdapterIdentifier(Adapter, Flags, pIdentifier);
-	}
-
-	STDMETHOD_(UINT, GetAdapterModeCount)(THIS_ UINT Adapter, D3DFORMAT Format) {
-		return this->original->GetAdapterCount();
-	}
-
-	STDMETHOD(EnumAdapterModes)(THIS_ UINT Adapter, D3DFORMAT Format, UINT Mode, D3DDISPLAYMODE* pMode) {
-		return this->original->EnumAdapterModes(Adapter, Format, Mode, pMode);
-	}
-
-	STDMETHOD(GetAdapterDisplayMode)(THIS_ UINT Adapter, D3DDISPLAYMODE* pMode) {
-		return this->original->GetAdapterDisplayMode(Adapter, pMode);
-	}
-
-	STDMETHOD(CheckDeviceType)(THIS_ UINT iAdapter, D3DDEVTYPE DevType, D3DFORMAT DisplayFormat, D3DFORMAT BackBufferFormat, BOOL bWindowed) {
-		return this->original->CheckDeviceType(iAdapter, DevType, DisplayFormat, BackBufferFormat, bWindowed);
-	}
-
-	STDMETHOD(CheckDeviceFormat)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, DWORD Usage, D3DRESOURCETYPE RType, D3DFORMAT CheckFormat) {
-		return this->original->CheckDeviceFormat(Adapter, DeviceType, AdapterFormat, Usage, RType, CheckFormat);
-	}
-
-	STDMETHOD(CheckDeviceMultiSampleType)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SurfaceFormat, BOOL Windowed, D3DMULTISAMPLE_TYPE MultiSampleType, DWORD* pQualityLevels) {
-		return this->original->CheckDeviceMultiSampleType(Adapter, DeviceType, SurfaceFormat, Windowed, MultiSampleType, pQualityLevels);
-	}
-
-	STDMETHOD(CheckDepthStencilMatch)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT AdapterFormat, D3DFORMAT RenderTargetFormat, D3DFORMAT DepthStencilFormat) {
-		return this->original->CheckDepthStencilMatch(Adapter, DeviceType, AdapterFormat, RenderTargetFormat, DepthStencilFormat);
-	}
-
-	STDMETHOD(CheckDeviceFormatConversion)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DFORMAT SourceFormat, D3DFORMAT TargetFormat) {
-		return this->original->CheckDeviceFormatConversion(Adapter, DeviceType, SourceFormat, TargetFormat);
-	}
-
-	STDMETHOD(GetDeviceCaps)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, D3DCAPS9* pCaps) {
-		return this->original->GetDeviceCaps(Adapter, DeviceType, pCaps);
-	}
-
-	STDMETHOD_(HMONITOR, GetAdapterMonitor)(THIS_ UINT Adapter) {
-		return this->original->GetAdapterMonitor(Adapter);
-	}
-
-	STDMETHOD(CreateDevice)(THIS_ UINT Adapter, D3DDEVTYPE DeviceType, HWND hFocusWindow, DWORD BehaviorFlags, D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DDevice9** ppReturnedDeviceInterface) {
-		TraceFunc();
-
-		TraceParam("BackBufferWidth", pPresentationParameters->BackBufferWidth);
-		TraceParam("BackBufferHeight", pPresentationParameters->BackBufferHeight);
-		TraceParam("Windowed", pPresentationParameters->Windowed);
-		TraceParam("MultiSampleType", pPresentationParameters->MultiSampleType);
-		TraceParam("MultiSampleQuality", pPresentationParameters->MultiSampleQuality);
-		TraceParam("SwapEffect", pPresentationParameters->SwapEffect);
-		TraceParam("AutoDepthStencilFormat", pPresentationParameters->AutoDepthStencilFormat);
-		TraceParam("PresentationInterval", pPresentationParameters->PresentationInterval);
-		
-		if (pPresentationParameters->BackBufferWidth == 800) {
-
-			TraceMsg("Back buffer updated");
-
-			/*pPresentationParameters->BackBufferWidth = 3840;
-			pPresentationParameters->BackBufferHeight = 2160;*/
-
-			// TODO: Read this from configuration
-			pPresentationParameters->BackBufferWidth = 1920;
-			pPresentationParameters->BackBufferHeight = 1080;
-			
-			//pPresentationParameters->Windowed = FALSE;
-		}
-
-		IDirect3DDevice9* trueDevice = nullptr;
-
-		HRESULT hResult = this->original->CreateDevice(Adapter, DeviceType, hFocusWindow, BehaviorFlags, pPresentationParameters, &trueDevice);
-
-		(*ppReturnedDeviceInterface) = new MyIDirect3DDevice9(trueDevice);
-
-		return hResult;
-	}
-
-	/*** Helper information ***/
-	LPCWSTR Version;
+    /*** Helper information ***/
+    LPCWSTR Version;
 };
 

--- a/src/OniPatch/MyIDirect3DDevice9.cpp
+++ b/src/OniPatch/MyIDirect3DDevice9.cpp
@@ -1,0 +1,646 @@
+#include "pch.h"
+#include "MyIDirect3DDevice9.h"
+
+MyIDirect3DDevice9::MyIDirect3DDevice9(IDirect3DDevice9 *original)
+{
+    this->original = original;
+
+    this->CreationParameters = this->original->CreationParameters;
+    this->PresentParameters = this->original->PresentParameters;
+    this->DisplayMode = this->original->DisplayMode;
+    this->Caps = this->original->Caps;
+
+    this->AvailableTextureMem = this->original->AvailableTextureMem;
+    this->SwapChains = this->original->SwapChains;
+    this->Textures = this->original->Textures;
+    this->VertexBuffers = this->original->VertexBuffers;
+    this->IndexBuffers = this->original->IndexBuffers;
+    this->VertexShaders = this->original->VertexShaders;
+    this->PixelShaders = this->original->PixelShaders;
+
+    this->Viewport = this->original->Viewport;
+    this->ProjectionMatrix = this->original->ProjectionMatrix;
+    this->ViewMatrix = this->original->ViewMatrix;
+    this->WorldMatrix = this->original->WorldMatrix;
+
+    for (int i = 0; i < 8; i++) {
+        this->TextureMatrices[i] = this->original->TextureMatrices[i];
+    }
+    //memcpy_s(this->TextureMatrices, sizeof(this->TextureMatrices), this->original->TextureMatrices, sizeof(this->original->TextureMatrices));
+
+    this->FVF = this->original->FVF;
+    this->VertexSize = this->original->VertexSize;
+    this->VertexShaderVersion = this->original->VertexShaderVersion;
+    this->PixelShaderVersion = this->original->PixelShaderVersion;
+    this->SoftwareVertexProcessing = this->original->SoftwareVertexProcessing;
+
+    this->Material = this->original->Material;
+
+    for (int i = 0; i < 16; i++) {
+        this->Lights[i] = this->original->Lights[i];
+        this->LightsEnabled[i] = this->original->LightsEnabled[i];
+    }
+    //memcpy_s(this->Lights, sizeof(this->Lights), this->original->Lights, sizeof(this->original->Lights));
+    //memcpy_s(this->LightsEnabled, sizeof(this->LightsEnabled), this->original->LightsEnabled, sizeof(this->original->LightsEnabled));
+
+    this->GammaRamp = this->original->GammaRamp;
+    this->ScissorRect = this->original->ScissorRect;
+    this->DialogBoxMode = this->original->DialogBoxMode;
+}
+
+/*** IUnknown methods ***/
+HRESULT MyIDirect3DDevice9::QueryInterface(REFIID riid, void **ppvObj)
+{
+    return this->original->QueryInterface(riid, ppvObj);
+}
+
+ULONG MyIDirect3DDevice9::AddRef(THIS)
+{
+    return this->original->AddRef();
+}
+
+ULONG MyIDirect3DDevice9::Release(THIS)
+{
+    return this->original->Release();
+}
+
+/*** IDirect3DDevice9 methods ***/
+HRESULT MyIDirect3DDevice9::TestCooperativeLevel(THIS)
+{
+    return this->original->TestCooperativeLevel();
+}
+
+UINT MyIDirect3DDevice9::GetAvailableTextureMem(THIS)
+{
+    return this->original->GetAvailableTextureMem();
+}
+
+HRESULT MyIDirect3DDevice9::EvictManagedResources(THIS)
+{
+    return this->original->EvictManagedResources();
+}
+
+HRESULT MyIDirect3DDevice9::GetDirect3D(IDirect3D9 **ppD3D9)
+{
+    return this->original->GetDirect3D(ppD3D9);
+}
+
+HRESULT MyIDirect3DDevice9::GetDeviceCaps(D3DCAPS9 *pCaps)
+{
+    return this->original->GetDeviceCaps(pCaps);
+}
+
+HRESULT MyIDirect3DDevice9::GetDisplayMode(UINT iSwapChain, D3DDISPLAYMODE *pMode)
+{
+    return this->original->GetDisplayMode(iSwapChain, pMode);
+}
+
+HRESULT MyIDirect3DDevice9::GetCreationParameters(D3DDEVICE_CREATION_PARAMETERS *pParameters)
+{
+    return this->original->GetCreationParameters(pParameters);
+}
+
+HRESULT MyIDirect3DDevice9::SetCursorProperties(UINT XHotSpot, UINT YHotSpot, IDirect3DSurface9 *pCursorBitmap)
+{
+    return this->original->SetCursorProperties(XHotSpot, YHotSpot, pCursorBitmap);
+}
+
+void MyIDirect3DDevice9::SetCursorPosition(int X, int Y, DWORD Flags)
+{
+    return this->original->SetCursorPosition(X, Y, Flags);
+}
+
+BOOL MyIDirect3DDevice9::ShowCursor(BOOL bShow)
+{
+    return this->original->ShowCursor(bShow);
+}
+
+HRESULT MyIDirect3DDevice9::CreateAdditionalSwapChain(D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DSwapChain9 **pSwapChain)
+{
+    return this->original->CreateAdditionalSwapChain(pPresentationParameters, pSwapChain);
+}
+
+HRESULT MyIDirect3DDevice9::GetSwapChain(UINT iSwapChain, IDirect3DSwapChain9 **pSwapChain)
+{
+    return this->original->GetSwapChain(iSwapChain, pSwapChain);
+}
+
+UINT MyIDirect3DDevice9::GetNumberOfSwapChains(THIS)
+{
+    return this->original->GetNumberOfSwapChains();
+}
+
+HRESULT MyIDirect3DDevice9::Reset(D3DPRESENT_PARAMETERS *pPresentationParameters)
+{
+    return this->original->Reset(pPresentationParameters);
+}
+
+HRESULT MyIDirect3DDevice9::Present(CONST RECT *pSourceRect, CONST RECT *pDestRect, HWND hDestWindowOverride, CONST RGNDATA *pDirtyRegion)
+{
+    return this->original->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
+}
+
+HRESULT MyIDirect3DDevice9::GetBackBuffer(UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9 **ppBackBuffer)
+{
+    return this->original->GetBackBuffer(iSwapChain, iBackBuffer, Type, ppBackBuffer);
+}
+
+HRESULT MyIDirect3DDevice9::GetRasterStatus(UINT iSwapChain, D3DRASTER_STATUS *pRasterStatus)
+{
+    return this->original->GetRasterStatus(iSwapChain, pRasterStatus);
+}
+
+HRESULT MyIDirect3DDevice9::SetDialogBoxMode(BOOL bEnableDialogs)
+{
+    return this->original->SetDialogBoxMode(bEnableDialogs);
+}
+
+void MyIDirect3DDevice9::SetGammaRamp(UINT iSwapChain, DWORD Flags, CONST D3DGAMMARAMP *pRamp)
+{
+    return this->original->SetGammaRamp(iSwapChain, Flags, pRamp);
+}
+
+void MyIDirect3DDevice9::GetGammaRamp(UINT iSwapChain, D3DGAMMARAMP *pRamp)
+{
+    return this->original->GetGammaRamp(iSwapChain, pRamp);
+}
+
+HRESULT MyIDirect3DDevice9::CreateTexture(UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle)
+{
+    return this->original->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateVolumeTexture(UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9 **ppVolumeTexture, HANDLE *pSharedHandle)
+{
+    return this->original->CreateVolumeTexture(Width, Height, Depth, Levels, Usage, Format, Pool, ppVolumeTexture, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateCubeTexture(UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9 **ppCubeTexture, HANDLE *pSharedHandle)
+{
+    return this->original->CreateCubeTexture(EdgeLength, Levels, Usage, Format, Pool, ppCubeTexture, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateVertexBuffer(UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9 **ppVertexBuffer, HANDLE *pSharedHandle)
+{
+    return this->original->CreateVertexBuffer(Length, Usage, FVF, Pool, ppVertexBuffer, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateIndexBuffer(UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer9 **ppIndexBuffer, HANDLE *pSharedHandle)
+{
+    return this->original->CreateIndexBuffer(Length, Usage, Format, Pool, ppIndexBuffer, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateRenderTarget(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle)
+{
+    return this->original->CreateRenderTarget(Width, Height, Format, MultiSample, MultisampleQuality, Lockable, ppSurface, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateDepthStencilSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle)
+{
+    return this->original->CreateDepthStencilSurface(Width, Height, Format, MultiSample, MultisampleQuality, Discard, ppSurface, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::UpdateSurface(IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRect, IDirect3DSurface9 *pDestinationSurface, CONST POINT *pDestPoint)
+{
+    return this->original->UpdateSurface(pSourceSurface, pSourceRect, pDestinationSurface, pDestPoint);
+}
+
+HRESULT MyIDirect3DDevice9::UpdateTexture(IDirect3DBaseTexture9 *pSourceTexture, IDirect3DBaseTexture9 *pDestinationTexture)
+{
+    return this->original->UpdateTexture(pSourceTexture, pDestinationTexture);
+}
+
+HRESULT MyIDirect3DDevice9::GetRenderTargetData(IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pDestSurface)
+{
+    return this->original->GetRenderTargetData(pRenderTarget, pDestSurface);
+}
+
+HRESULT MyIDirect3DDevice9::GetFrontBufferData(UINT iSwapChain, IDirect3DSurface9 *pDestSurface)
+{
+    return this->original->GetFrontBufferData(iSwapChain, pDestSurface);
+}
+
+HRESULT MyIDirect3DDevice9::StretchRect(IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRect, IDirect3DSurface9 *pDestSurface, CONST RECT *pDestRect, D3DTEXTUREFILTERTYPE Filter)
+{
+    return this->original->StretchRect(pSourceSurface, pSourceRect, pDestSurface, pDestRect, Filter);
+}
+
+HRESULT MyIDirect3DDevice9::ColorFill(IDirect3DSurface9 *pSurface, CONST RECT *pRect, D3DCOLOR color)
+{
+    return this->original->ColorFill(pSurface, pRect, color);
+}
+
+HRESULT MyIDirect3DDevice9::CreateOffscreenPlainSurface(UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle)
+{
+    return this->original->CreateOffscreenPlainSurface(Width, Height, Format, Pool, ppSurface, pSharedHandle);
+}
+
+HRESULT MyIDirect3DDevice9::SetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 *pRenderTarget)
+{
+    return this->original->SetRenderTarget(RenderTargetIndex, pRenderTarget);
+}
+
+HRESULT MyIDirect3DDevice9::GetRenderTarget(DWORD RenderTargetIndex, IDirect3DSurface9 **ppRenderTarget)
+{
+    return this->original->GetRenderTarget(RenderTargetIndex, ppRenderTarget);
+}
+
+HRESULT MyIDirect3DDevice9::SetDepthStencilSurface(IDirect3DSurface9 *pNewZStencil)
+{
+    return this->original->SetDepthStencilSurface(pNewZStencil);
+}
+
+HRESULT MyIDirect3DDevice9::GetDepthStencilSurface(IDirect3DSurface9 **ppZStencilSurface)
+{
+    return this->original->GetDepthStencilSurface(ppZStencilSurface);
+}
+
+HRESULT MyIDirect3DDevice9::BeginScene(THIS)
+{
+    return this->original->BeginScene();
+}
+
+HRESULT MyIDirect3DDevice9::EndScene(THIS)
+{
+    return this->original->EndScene();
+}
+
+HRESULT MyIDirect3DDevice9::Clear(DWORD Count, CONST D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil)
+{
+    return this->original->Clear(Count, pRects, Flags, Color, Z, Stencil);
+}
+
+HRESULT MyIDirect3DDevice9::SetTransform(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX *pMatrix)
+{
+    return this->original->SetTransform(State, pMatrix);
+}
+
+HRESULT MyIDirect3DDevice9::GetTransform(D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix)
+{
+    return this->original->GetTransform(State, pMatrix);
+}
+
+HRESULT MyIDirect3DDevice9::MultiplyTransform(D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX *pMatrix)
+{
+    return this->original->MultiplyTransform(State, pMatrix);
+}
+
+HRESULT MyIDirect3DDevice9::SetViewport(CONST D3DVIEWPORT9 *pViewport)
+{
+    return this->original->SetViewport(pViewport);
+}
+
+HRESULT MyIDirect3DDevice9::GetViewport(D3DVIEWPORT9 *pViewport)
+{
+    return this->original->GetViewport(pViewport);
+}
+
+HRESULT MyIDirect3DDevice9::SetMaterial(CONST D3DMATERIAL9 *pMaterial)
+{
+    return this->original->SetMaterial(pMaterial);
+}
+
+HRESULT MyIDirect3DDevice9::GetMaterial(D3DMATERIAL9 *pMaterial)
+{
+    return this->original->GetMaterial(pMaterial);
+}
+
+HRESULT MyIDirect3DDevice9::SetLight(DWORD Index, CONST D3DLIGHT9 *pLight)
+{
+    return this->original->SetLight(Index, pLight);
+}
+
+HRESULT MyIDirect3DDevice9::GetLight(DWORD Index, D3DLIGHT9 *pLight)
+{
+    return this->original->GetLight(Index, pLight);
+}
+
+HRESULT MyIDirect3DDevice9::LightEnable(DWORD Index, BOOL Enable)
+{
+    return this->original->LightEnable(Index, Enable);
+}
+
+HRESULT MyIDirect3DDevice9::GetLightEnable(DWORD Index, BOOL *pEnable)
+{
+    return this->original->GetLightEnable(Index, pEnable);
+}
+
+HRESULT MyIDirect3DDevice9::SetClipPlane(DWORD Index, CONST float *pPlane)
+{
+    return this->original->SetClipPlane(Index, pPlane);
+}
+
+HRESULT MyIDirect3DDevice9::GetClipPlane(DWORD Index, float *pPlane)
+{
+    return this->original->GetClipPlane(Index, pPlane);
+}
+
+HRESULT MyIDirect3DDevice9::SetRenderState(D3DRENDERSTATETYPE State, DWORD Value)
+{
+    return this->original->SetRenderState(State, Value);
+}
+
+HRESULT MyIDirect3DDevice9::GetRenderState(D3DRENDERSTATETYPE State, DWORD *pValue)
+{
+    return this->original->GetRenderState(State, pValue);
+}
+
+HRESULT MyIDirect3DDevice9::CreateStateBlock(D3DSTATEBLOCKTYPE Type, IDirect3DStateBlock9 **ppSB)
+{
+    return this->original->CreateStateBlock(Type, ppSB);
+}
+
+HRESULT MyIDirect3DDevice9::BeginStateBlock(THIS)
+{
+    return this->original->BeginStateBlock();
+}
+
+HRESULT MyIDirect3DDevice9::EndStateBlock(IDirect3DStateBlock9 **ppSB)
+{
+    return this->original->EndStateBlock(ppSB);
+}
+
+HRESULT MyIDirect3DDevice9::SetClipStatus(CONST D3DCLIPSTATUS9 *pClipStatus)
+{
+    return this->original->SetClipStatus(pClipStatus);
+}
+
+HRESULT MyIDirect3DDevice9::GetClipStatus(D3DCLIPSTATUS9 *pClipStatus)
+{
+    return this->original->GetClipStatus(pClipStatus);
+}
+
+HRESULT MyIDirect3DDevice9::GetTexture(DWORD Stage, IDirect3DBaseTexture9 **ppTexture)
+{
+    return this->original->GetTexture(Stage, ppTexture);
+}
+
+HRESULT MyIDirect3DDevice9::SetTexture(DWORD Stage, IDirect3DBaseTexture9 *pTexture)
+{
+    return this->original->SetTexture(Stage, pTexture);
+}
+
+HRESULT MyIDirect3DDevice9::GetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD *pValue)
+{
+    return this->original->GetTextureStageState(Stage, Type, pValue);
+}
+
+HRESULT MyIDirect3DDevice9::SetTextureStageState(DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value)
+{
+    return this->original->SetTextureStageState(Stage, Type, Value);
+}
+
+HRESULT MyIDirect3DDevice9::GetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD *pValue)
+{
+    return this->original->GetSamplerState(Sampler, Type, pValue);
+}
+
+HRESULT MyIDirect3DDevice9::SetSamplerState(DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value)
+{
+    return this->original->SetSamplerState(Sampler, Type, Value);
+}
+
+HRESULT MyIDirect3DDevice9::ValidateDevice(DWORD *pNumPasses)
+{
+    return this->original->ValidateDevice(pNumPasses);
+}
+
+HRESULT MyIDirect3DDevice9::SetPaletteEntries(UINT PaletteNumber, CONST PALETTEENTRY *pEntries)
+{
+    return this->original->SetPaletteEntries(PaletteNumber, pEntries);
+}
+
+HRESULT MyIDirect3DDevice9::GetPaletteEntries(UINT PaletteNumber, PALETTEENTRY *pEntries)
+{
+    return this->original->GetPaletteEntries(PaletteNumber, pEntries);
+}
+
+HRESULT MyIDirect3DDevice9::SetCurrentTexturePalette(UINT PaletteNumber)
+{
+    return this->original->SetCurrentTexturePalette(PaletteNumber);
+}
+
+HRESULT MyIDirect3DDevice9::GetCurrentTexturePalette(UINT *PaletteNumber)
+{
+    return this->original->GetCurrentTexturePalette(PaletteNumber);
+}
+
+HRESULT MyIDirect3DDevice9::SetScissorRect(CONST RECT *pRect)
+{
+    return this->original->SetScissorRect(pRect);
+}
+
+HRESULT MyIDirect3DDevice9::GetScissorRect(RECT *pRect)
+{
+    return this->original->GetScissorRect(pRect);
+}
+
+HRESULT MyIDirect3DDevice9::SetSoftwareVertexProcessing(BOOL bSoftware)
+{
+    return this->original->SetSoftwareVertexProcessing(bSoftware);
+}
+
+BOOL MyIDirect3DDevice9::GetSoftwareVertexProcessing(THIS)
+{
+    return this->original->GetSoftwareVertexProcessing();
+}
+
+HRESULT MyIDirect3DDevice9::SetNPatchMode(float nSegments)
+{
+    return this->original->SetNPatchMode(nSegments);
+}
+
+float MyIDirect3DDevice9::GetNPatchMode(THIS)
+{
+    return this->original->GetNPatchMode();
+}
+
+HRESULT MyIDirect3DDevice9::DrawPrimitive(D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount)
+{
+    return this->original->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
+}
+
+HRESULT MyIDirect3DDevice9::DrawIndexedPrimitive(D3DPRIMITIVETYPE PrimitiveType, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex, UINT primCount)
+{
+    return this->original->DrawIndexedPrimitive(PrimitiveType, BaseVertexIndex, MinVertexIndex, NumVertices, startIndex, primCount);
+}
+
+HRESULT MyIDirect3DDevice9::DrawPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void *pVertexStreamZeroData, UINT VertexStreamZeroStride)
+{
+    return this->original->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
+}
+
+HRESULT MyIDirect3DDevice9::DrawIndexedPrimitiveUP(D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void *pIndexData, D3DFORMAT IndexDataFormat, CONST void *pVertexStreamZeroData, UINT VertexStreamZeroStride)
+{
+    return this->original->DrawIndexedPrimitiveUP(PrimitiveType, MinVertexIndex, NumVertices, PrimitiveCount, pIndexData, IndexDataFormat, pVertexStreamZeroData, VertexStreamZeroStride);
+}
+
+HRESULT MyIDirect3DDevice9::ProcessVertices(UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer9 *pDestBuffer, IDirect3DVertexDeclaration9 *pVertexDecl, DWORD Flags)
+{
+    return this->original->ProcessVertices(SrcStartIndex, DestIndex, VertexCount, pDestBuffer, pVertexDecl, Flags);
+}
+
+HRESULT MyIDirect3DDevice9::CreateVertexDeclaration(CONST D3DVERTEXELEMENT9 *pVertexElements, IDirect3DVertexDeclaration9 **ppDecl)
+{
+    return this->original->CreateVertexDeclaration(pVertexElements, ppDecl);
+}
+
+HRESULT MyIDirect3DDevice9::SetVertexDeclaration(IDirect3DVertexDeclaration9 *pDecl)
+{
+    return this->original->SetVertexDeclaration(pDecl);
+}
+
+HRESULT MyIDirect3DDevice9::GetVertexDeclaration(IDirect3DVertexDeclaration9 **ppDecl)
+{
+    return this->original->GetVertexDeclaration(ppDecl);
+}
+
+HRESULT MyIDirect3DDevice9::SetFVF(DWORD FVF)
+{
+    return this->original->SetFVF(FVF);
+}
+
+HRESULT MyIDirect3DDevice9::GetFVF(DWORD *pFVF)
+{
+    return this->original->GetFVF(pFVF);
+}
+
+HRESULT MyIDirect3DDevice9::CreateVertexShader(CONST DWORD *pFunction, IDirect3DVertexShader9 **ppShader)
+{
+    return this->original->CreateVertexShader(pFunction, ppShader);
+}
+
+HRESULT MyIDirect3DDevice9::SetVertexShader(IDirect3DVertexShader9 *pShader)
+{
+    return this->original->SetVertexShader(pShader);
+}
+
+HRESULT MyIDirect3DDevice9::GetVertexShader(IDirect3DVertexShader9 **ppShader)
+{
+    return this->original->GetVertexShader(ppShader);
+}
+
+HRESULT MyIDirect3DDevice9::SetVertexShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4fCount)
+{
+    return this->original->SetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetVertexShaderConstantF(UINT StartRegister, float *pConstantData, UINT Vector4fCount)
+{
+    return this->original->GetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+}
+
+HRESULT MyIDirect3DDevice9::SetVertexShaderConstantI(UINT StartRegister, CONST INT *pConstantData, UINT Vector4iCount)
+{
+    return this->original->SetVertexShaderConstantI(StartRegister, pConstantData, Vector4iCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetVertexShaderConstantI(UINT StartRegister, INT *pConstantData, UINT Vector4iCount)
+{
+    return this->original->GetVertexShaderConstantI(StartRegister, pConstantData, Vector4iCount);
+}
+
+HRESULT MyIDirect3DDevice9::SetVertexShaderConstantB(UINT StartRegister, CONST BOOL *pConstantData, UINT BoolCount)
+{
+    return this->original->SetVertexShaderConstantB(StartRegister, pConstantData, BoolCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetVertexShaderConstantB(UINT StartRegister, BOOL *pConstantData, UINT BoolCount)
+{
+    return this->original->GetVertexShaderConstantB(StartRegister, pConstantData, BoolCount);
+}
+
+HRESULT MyIDirect3DDevice9::SetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9 *pStreamData, UINT OffsetInBytes, UINT Stride)
+{
+    return this->original->SetStreamSource(StreamNumber, pStreamData, OffsetInBytes, Stride);
+}
+
+HRESULT MyIDirect3DDevice9::GetStreamSource(UINT StreamNumber, IDirect3DVertexBuffer9 **ppStreamData, UINT *OffsetInBytes, UINT *pStride)
+{
+    return this->original->GetStreamSource(StreamNumber, ppStreamData, OffsetInBytes, pStride);
+}
+
+HRESULT MyIDirect3DDevice9::SetStreamSourceFreq(UINT StreamNumber, UINT Divider)
+{
+    return this->original->SetStreamSourceFreq(StreamNumber, Divider);
+}
+
+HRESULT MyIDirect3DDevice9::GetStreamSourceFreq(UINT StreamNumber, UINT *Divider)
+{
+    return this->original->GetStreamSourceFreq(StreamNumber, Divider);
+}
+
+HRESULT MyIDirect3DDevice9::SetIndices(IDirect3DIndexBuffer9 *pIndexData)
+{
+    return this->original->SetIndices(pIndexData);
+}
+
+HRESULT MyIDirect3DDevice9::GetIndices(IDirect3DIndexBuffer9 **ppIndexData)
+{
+    return this->original->GetIndices(ppIndexData);
+}
+
+HRESULT MyIDirect3DDevice9::CreatePixelShader(CONST DWORD *pFunction, IDirect3DPixelShader9 **ppShader)
+{
+    return this->original->CreatePixelShader(pFunction, ppShader);
+}
+
+HRESULT MyIDirect3DDevice9::SetPixelShader(IDirect3DPixelShader9 *pShader)
+{
+    return this->original->SetPixelShader(pShader);
+}
+
+HRESULT MyIDirect3DDevice9::GetPixelShader(IDirect3DPixelShader9 **ppShader)
+{
+    return this->original->GetPixelShader(ppShader);
+}
+
+HRESULT MyIDirect3DDevice9::SetPixelShaderConstantF(UINT StartRegister, CONST float *pConstantData, UINT Vector4fCount)
+{
+    return this->original->SetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetPixelShaderConstantF(UINT StartRegister, float *pConstantData, UINT Vector4fCount)
+{
+    return this->original->GetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
+}
+
+HRESULT MyIDirect3DDevice9::SetPixelShaderConstantI(UINT StartRegister, CONST INT *pConstantData, UINT Vector4iCount)
+{
+    return this->original->SetPixelShaderConstantI(StartRegister, pConstantData, Vector4iCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetPixelShaderConstantI(UINT StartRegister, INT *pConstantData, UINT Vector4iCount)
+{
+    return this->original->GetPixelShaderConstantI(StartRegister, pConstantData, Vector4iCount);
+}
+
+HRESULT MyIDirect3DDevice9::SetPixelShaderConstantB(UINT StartRegister, CONST BOOL *pConstantData, UINT  BoolCount)
+{
+    return this->original->SetPixelShaderConstantB(StartRegister, pConstantData, BoolCount);
+}
+
+HRESULT MyIDirect3DDevice9::GetPixelShaderConstantB(UINT StartRegister, BOOL *pConstantData, UINT BoolCount)
+{
+    return this->original->GetPixelShaderConstantB(StartRegister, pConstantData, BoolCount);
+}
+
+HRESULT MyIDirect3DDevice9::DrawRectPatch(UINT Handle, CONST float *pNumSegs, CONST D3DRECTPATCH_INFO *pRectPatchInfo)
+{
+    return this->original->DrawRectPatch(Handle, pNumSegs, pRectPatchInfo);
+}
+
+HRESULT MyIDirect3DDevice9::DrawTriPatch(UINT Handle, CONST float *pNumSegs, CONST D3DTRIPATCH_INFO *pTriPatchInfo)
+{
+    return this->original->DrawTriPatch(Handle, pNumSegs, pTriPatchInfo);
+}
+
+HRESULT MyIDirect3DDevice9::DeletePatch(UINT Handle)
+{
+    return this->original->DeletePatch(Handle);
+}
+
+HRESULT MyIDirect3DDevice9::CreateQuery(D3DQUERYTYPE Type, IDirect3DQuery9 **ppQuery)
+{
+    return this->original->CreateQuery(Type, ppQuery);
+}

--- a/src/OniPatch/MyIDirect3DDevice9.h
+++ b/src/OniPatch/MyIDirect3DDevice9.h
@@ -1,496 +1,137 @@
 #pragma once
-#include <d3d9helper.h>
-#include "Trace.h"
+
+#include "pch.h"
 
 class MyIDirect3DDevice9 : public IDirect3DDevice9
 {
 private:
-    IDirect3DDevice9* original;
+    IDirect3DDevice9 *original;
 
 public:
-    MyIDirect3DDevice9(IDirect3DDevice9* original) {
-        this->original = original;
-        //(&(this->CreationParameters)) = this->original->CreationParameters;
-    }
+    MyIDirect3DDevice9(IDirect3DDevice9 *original);
 
     /*** IUnknown methods ***/
-    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void** ppvObj) {
-        return this->original->QueryInterface(riid, ppvObj);
-    }
-
-    STDMETHOD_(ULONG, AddRef)(THIS) {
-        return this->original->AddRef();
-    }
-
-    STDMETHOD_(ULONG, Release)(THIS) {
-        return this->original->Release();
-    }
+    STDMETHOD(QueryInterface)(THIS_ REFIID riid, void **ppvObj);
+    STDMETHOD_(ULONG, AddRef)(THIS);
+    STDMETHOD_(ULONG, Release)(THIS);
 
     /*** IDirect3DDevice9 methods ***/
-    STDMETHOD(TestCooperativeLevel)(THIS) {
-        return this->original->TestCooperativeLevel();
-    }
-
-    STDMETHOD_(UINT, GetAvailableTextureMem)(THIS) {
-        return this->original->GetAvailableTextureMem();
-    }
-
-    STDMETHOD(EvictManagedResources)(THIS) {
-        return this->original->EvictManagedResources();
-    }
-
-    STDMETHOD(GetDirect3D)(THIS_ IDirect3D9** ppD3D9) {
-        return this->original->GetDirect3D(ppD3D9);
-    }
-
-    STDMETHOD(GetDeviceCaps)(THIS_ D3DCAPS9* pCaps) {
-        return this->original->GetDeviceCaps(pCaps);
-    }
-
-    STDMETHOD(GetDisplayMode)(THIS_ UINT iSwapChain, D3DDISPLAYMODE* pMode) {
-        return this->original->GetDisplayMode(iSwapChain, pMode);
-    }
-
-    STDMETHOD(GetCreationParameters)(THIS_ D3DDEVICE_CREATION_PARAMETERS* pParameters) {
-        return this->original->GetCreationParameters(pParameters);
-    }
-
-    STDMETHOD(SetCursorProperties)(THIS_ UINT XHotSpot, UINT YHotSpot, IDirect3DSurface9* pCursorBitmap) {
-        return this->original->SetCursorProperties(XHotSpot, YHotSpot, pCursorBitmap);
-    }
-
-    STDMETHOD_(void, SetCursorPosition)(THIS_ int X, int Y, DWORD Flags) {
-        return this->original->SetCursorPosition(X, Y, Flags);
-    }
-
-    STDMETHOD_(BOOL, ShowCursor)(THIS_ BOOL bShow) {
-        return this->original->ShowCursor(bShow);
-    }
-
-    STDMETHOD(CreateAdditionalSwapChain)(THIS_ D3DPRESENT_PARAMETERS* pPresentationParameters, IDirect3DSwapChain9** pSwapChain) {
-        return this->original->CreateAdditionalSwapChain(pPresentationParameters, pSwapChain);
-    }
-
-    STDMETHOD(GetSwapChain)(THIS_ UINT iSwapChain, IDirect3DSwapChain9** pSwapChain) {
-        return this->original->GetSwapChain(iSwapChain, pSwapChain);
-    }
-
-    STDMETHOD_(UINT, GetNumberOfSwapChains)(THIS) {
-        return this->original->GetNumberOfSwapChains();
-    }
-
-    STDMETHOD(Reset)(THIS_ D3DPRESENT_PARAMETERS* pPresentationParameters) {
-        return this->original->Reset(pPresentationParameters);
-    }
-
-    STDMETHOD(Present)(THIS_ CONST RECT* pSourceRect, CONST RECT* pDestRect, HWND hDestWindowOverride, CONST RGNDATA* pDirtyRegion) {
-        return this->original->Present(pSourceRect, pDestRect, hDestWindowOverride, pDirtyRegion);
-    }
-
-    STDMETHOD(GetBackBuffer)(THIS_ UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9** ppBackBuffer) {
-        return this->original->GetBackBuffer(iSwapChain, iBackBuffer, Type, ppBackBuffer);
-    }
-
-    STDMETHOD(GetRasterStatus)(THIS_ UINT iSwapChain, D3DRASTER_STATUS* pRasterStatus) {
-        return this->original->GetRasterStatus(iSwapChain, pRasterStatus);
-    }
-
-    STDMETHOD(SetDialogBoxMode)(THIS_ BOOL bEnableDialogs) {
-        return this->original->SetDialogBoxMode(bEnableDialogs);
-    }
-
-    STDMETHOD_(void, SetGammaRamp)(THIS_ UINT iSwapChain, DWORD Flags, CONST D3DGAMMARAMP* pRamp) {
-        return this->original->SetGammaRamp(iSwapChain, Flags, pRamp);
-    }
-
-    STDMETHOD_(void, GetGammaRamp)(THIS_ UINT iSwapChain, D3DGAMMARAMP* pRamp) {
-        return this->original->GetGammaRamp(iSwapChain, pRamp);
-    }
-
-    STDMETHOD(CreateTexture)(THIS_ UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9** ppTexture, HANDLE* pSharedHandle) {
-        return this->original->CreateTexture(Width, Height, Levels, Usage, Format, Pool, ppTexture, pSharedHandle);
-    }
-
-    STDMETHOD(CreateVolumeTexture)(THIS_ UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9** ppVolumeTexture, HANDLE* pSharedHandle) {
-        return this->original->CreateVolumeTexture(Width, Height, Depth, Levels, Usage, Format, Pool, ppVolumeTexture, pSharedHandle);
-    }
-
-    STDMETHOD(CreateCubeTexture)(THIS_ UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9** ppCubeTexture, HANDLE* pSharedHandle) {
-        return this->original->CreateCubeTexture(EdgeLength, Levels, Usage, Format, Pool, ppCubeTexture, pSharedHandle);
-    }
-
-    STDMETHOD(CreateVertexBuffer)(THIS_ UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9** ppVertexBuffer, HANDLE* pSharedHandle) {
-        return this->original->CreateVertexBuffer(Length, Usage, FVF, Pool, ppVertexBuffer, pSharedHandle);
-    }
-
-    STDMETHOD(CreateIndexBuffer)(THIS_ UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer9** ppIndexBuffer, HANDLE* pSharedHandle) {
-        return this->original->CreateIndexBuffer(Length, Usage, Format, Pool, ppIndexBuffer, pSharedHandle);
-    }
-
-    STDMETHOD(CreateRenderTarget)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle) {
-        return this->original->CreateRenderTarget(Width, Height, Format, MultiSample, MultisampleQuality, Lockable, ppSurface, pSharedHandle);
-    }
-
-    STDMETHOD(CreateDepthStencilSurface)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle) {
-        return this->original->CreateDepthStencilSurface(Width, Height, Format, MultiSample, MultisampleQuality, Discard, ppSurface, pSharedHandle);
-    }
-
-    STDMETHOD(UpdateSurface)(THIS_ IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestinationSurface, CONST POINT* pDestPoint) {
-        return this->original->UpdateSurface(pSourceSurface, pSourceRect, pDestinationSurface, pDestPoint);
-    }
-
-    STDMETHOD(UpdateTexture)(THIS_ IDirect3DBaseTexture9* pSourceTexture, IDirect3DBaseTexture9* pDestinationTexture) {
-        return this->original->UpdateTexture(pSourceTexture, pDestinationTexture);
-    }
-
-    STDMETHOD(GetRenderTargetData)(THIS_ IDirect3DSurface9* pRenderTarget, IDirect3DSurface9* pDestSurface) {
-        return this->original->GetRenderTargetData(pRenderTarget, pDestSurface);
-    }
-
-    STDMETHOD(GetFrontBufferData)(THIS_ UINT iSwapChain, IDirect3DSurface9* pDestSurface) {
-        return this->original->GetFrontBufferData(iSwapChain, pDestSurface);
-    }
-
-    STDMETHOD(StretchRect)(THIS_ IDirect3DSurface9* pSourceSurface, CONST RECT* pSourceRect, IDirect3DSurface9* pDestSurface, CONST RECT* pDestRect, D3DTEXTUREFILTERTYPE Filter) {
-        return this->original->StretchRect(pSourceSurface, pSourceRect, pDestSurface, pDestRect, Filter);
-    }
-
-    STDMETHOD(ColorFill)(THIS_ IDirect3DSurface9* pSurface, CONST RECT* pRect, D3DCOLOR color) {
-        return this->original->ColorFill(pSurface, pRect, color);
-    }
-
-    STDMETHOD(CreateOffscreenPlainSurface)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9** ppSurface, HANDLE* pSharedHandle) {
-        return this->original->CreateOffscreenPlainSurface(Width, Height, Format, Pool, ppSurface, pSharedHandle);
-    }
-
-    STDMETHOD(SetRenderTarget)(THIS_ DWORD RenderTargetIndex, IDirect3DSurface9* pRenderTarget) {
-        return this->original->SetRenderTarget(RenderTargetIndex, pRenderTarget);
-    }
-
-    STDMETHOD(GetRenderTarget)(THIS_ DWORD RenderTargetIndex, IDirect3DSurface9** ppRenderTarget) {
-        return this->original->GetRenderTarget(RenderTargetIndex, ppRenderTarget);
-    }
-
-    STDMETHOD(SetDepthStencilSurface)(THIS_ IDirect3DSurface9* pNewZStencil) {
-        return this->original->SetDepthStencilSurface(pNewZStencil);
-    }
-
-    STDMETHOD(GetDepthStencilSurface)(THIS_ IDirect3DSurface9** ppZStencilSurface) {
-        return this->original->GetDepthStencilSurface(ppZStencilSurface);
-    }
-
-    STDMETHOD(BeginScene)(THIS) {
-        return this->original->BeginScene();
-    }
-
-    STDMETHOD(EndScene)(THIS) {
-        return this->original->EndScene();
-    }
-
-    STDMETHOD(Clear)(THIS_ DWORD Count, CONST D3DRECT* pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil) {
-        return this->original->Clear(Count, pRects, Flags, Color, Z, Stencil);
-    }
-
-    STDMETHOD(SetTransform)(THIS_ D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix) {
-        return this->original->SetTransform(State, pMatrix);
-    }
-
-    STDMETHOD(GetTransform)(THIS_ D3DTRANSFORMSTATETYPE State, D3DMATRIX* pMatrix) {
-        return this->original->GetTransform(State, pMatrix);
-    }
-
-    STDMETHOD(MultiplyTransform)(THIS_ D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX* pMatrix) {
-        return this->original->MultiplyTransform(State, pMatrix);
-    }
-
-    STDMETHOD(SetViewport)(THIS_ CONST D3DVIEWPORT9* pViewport) {
-        return this->original->SetViewport(pViewport);
-    }
-
-    STDMETHOD(GetViewport)(THIS_ D3DVIEWPORT9* pViewport) {
-        return this->original->GetViewport(pViewport);
-    }
-
-    STDMETHOD(SetMaterial)(THIS_ CONST D3DMATERIAL9* pMaterial) {
-        return this->original->SetMaterial(pMaterial);
-    }
-
-    STDMETHOD(GetMaterial)(THIS_ D3DMATERIAL9* pMaterial) {
-        return this->original->GetMaterial(pMaterial);
-    }
-
-    STDMETHOD(SetLight)(THIS_ DWORD Index, CONST D3DLIGHT9* pLight) {
-        return this->original->SetLight(Index, pLight);
-    }
-
-    STDMETHOD(GetLight)(THIS_ DWORD Index, D3DLIGHT9* pLight) {
-        return this->original->GetLight(Index, pLight);
-    }
-
-    STDMETHOD(LightEnable)(THIS_ DWORD Index, BOOL Enable) {
-        return this->original->LightEnable(Index, Enable);
-    }
-
-    STDMETHOD(GetLightEnable)(THIS_ DWORD Index, BOOL* pEnable) {
-        return this->original->GetLightEnable(Index, pEnable);
-    }
-
-    STDMETHOD(SetClipPlane)(THIS_ DWORD Index, CONST float* pPlane) {
-        return this->original->SetClipPlane(Index, pPlane);
-    }
-
-    STDMETHOD(GetClipPlane)(THIS_ DWORD Index, float* pPlane) {
-        return this->original->GetClipPlane(Index, pPlane);
-    }
-
-    STDMETHOD(SetRenderState)(THIS_ D3DRENDERSTATETYPE State, DWORD Value) {
-        return this->original->SetRenderState(State, Value);
-    }
-
-    STDMETHOD(GetRenderState)(THIS_ D3DRENDERSTATETYPE State, DWORD* pValue) {
-        return this->original->GetRenderState(State, pValue);
-    }
-
-    STDMETHOD(CreateStateBlock)(THIS_ D3DSTATEBLOCKTYPE Type, IDirect3DStateBlock9** ppSB) {
-        return this->original->CreateStateBlock(Type, ppSB);
-    }
-
-    STDMETHOD(BeginStateBlock)(THIS) {
-        return this->original->BeginStateBlock();
-    }
-
-    STDMETHOD(EndStateBlock)(THIS_ IDirect3DStateBlock9** ppSB) {
-        return this->original->EndStateBlock(ppSB);
-    }
-
-    STDMETHOD(SetClipStatus)(THIS_ CONST D3DCLIPSTATUS9* pClipStatus) {
-        return this->original->SetClipStatus(pClipStatus);
-    }
-
-    STDMETHOD(GetClipStatus)(THIS_ D3DCLIPSTATUS9* pClipStatus) {
-        return this->original->GetClipStatus(pClipStatus);
-    }
-
-    STDMETHOD(GetTexture)(THIS_ DWORD Stage, IDirect3DBaseTexture9** ppTexture) {
-        return this->original->GetTexture(Stage, ppTexture);
-    }
-
-    STDMETHOD(SetTexture)(THIS_ DWORD Stage, IDirect3DBaseTexture9* pTexture) {
-        return this->original->SetTexture(Stage, pTexture);
-    }
-
-    STDMETHOD(GetTextureStageState)(THIS_ DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD* pValue) {
-        return this->original->GetTextureStageState(Stage, Type, pValue);
-    }
-
-    STDMETHOD(SetTextureStageState)(THIS_ DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value) {
-        return this->original->SetTextureStageState(Stage, Type, Value);
-    }
-
-    STDMETHOD(GetSamplerState)(THIS_ DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD* pValue) {
-        return this->original->GetSamplerState(Sampler, Type, pValue);
-    }
-
-    STDMETHOD(SetSamplerState)(THIS_ DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value) {
-        return this->original->SetSamplerState(Sampler, Type, Value);
-    }
-
-    STDMETHOD(ValidateDevice)(THIS_ DWORD* pNumPasses) {
-        return this->original->ValidateDevice(pNumPasses);
-    }
-
-    STDMETHOD(SetPaletteEntries)(THIS_ UINT PaletteNumber, CONST PALETTEENTRY* pEntries) {
-        return this->original->SetPaletteEntries(PaletteNumber, pEntries);
-    }
-
-    STDMETHOD(GetPaletteEntries)(THIS_ UINT PaletteNumber, PALETTEENTRY* pEntries) {
-        return this->original->GetPaletteEntries(PaletteNumber, pEntries);
-    }
-
-    STDMETHOD(SetCurrentTexturePalette)(THIS_ UINT PaletteNumber) {
-        return this->original->SetCurrentTexturePalette(PaletteNumber);
-    }
-
-    STDMETHOD(GetCurrentTexturePalette)(THIS_ UINT* PaletteNumber) {
-        return this->original->GetCurrentTexturePalette(PaletteNumber);
-    }
-
-    STDMETHOD(SetScissorRect)(THIS_ CONST RECT* pRect) {
-        return this->original->SetScissorRect(pRect);
-    }
-
-    STDMETHOD(GetScissorRect)(THIS_ RECT* pRect) {
-        return this->original->GetScissorRect(pRect);
-    }
-
-    STDMETHOD(SetSoftwareVertexProcessing)(THIS_ BOOL bSoftware) {
-        return this->original->SetSoftwareVertexProcessing(bSoftware);
-    }
-
-    STDMETHOD_(BOOL, GetSoftwareVertexProcessing)(THIS) {
-        return this->original->GetSoftwareVertexProcessing();
-    }
-
-    STDMETHOD(SetNPatchMode)(THIS_ float nSegments) {
-        return this->original->SetNPatchMode(nSegments);
-    }
-
-    STDMETHOD_(float, GetNPatchMode)(THIS) {
-        return this->original->GetNPatchMode();
-    }
-
-    STDMETHOD(DrawPrimitive)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount) {
-        return this->original->DrawPrimitive(PrimitiveType, StartVertex, PrimitiveCount);
-    }
-
-    STDMETHOD(DrawIndexedPrimitive)(THIS_ D3DPRIMITIVETYPE PrimitiveType, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex, UINT primCount) {
-        return this->original->DrawIndexedPrimitive(PrimitiveType, BaseVertexIndex, MinVertexIndex, NumVertices, startIndex, primCount);
-    }
-
-    STDMETHOD(DrawPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
-        return this->original->DrawPrimitiveUP(PrimitiveType, PrimitiveCount, pVertexStreamZeroData, VertexStreamZeroStride);
-    }
-
-    STDMETHOD(DrawIndexedPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void* pIndexData, D3DFORMAT IndexDataFormat, CONST void* pVertexStreamZeroData, UINT VertexStreamZeroStride) {
-        return this->original->DrawIndexedPrimitiveUP(PrimitiveType, MinVertexIndex, NumVertices, PrimitiveCount, pIndexData, IndexDataFormat, pVertexStreamZeroData, VertexStreamZeroStride);
-    }
-
-    STDMETHOD(ProcessVertices)(THIS_ UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer9* pDestBuffer, IDirect3DVertexDeclaration9* pVertexDecl, DWORD Flags) {
-        return this->original->ProcessVertices(SrcStartIndex, DestIndex, VertexCount, pDestBuffer, pVertexDecl, Flags);
-    }
-
-    STDMETHOD(CreateVertexDeclaration)(THIS_ CONST D3DVERTEXELEMENT9* pVertexElements, IDirect3DVertexDeclaration9** ppDecl) {
-        return this->original->CreateVertexDeclaration(pVertexElements, ppDecl);
-    }
-
-    STDMETHOD(SetVertexDeclaration)(THIS_ IDirect3DVertexDeclaration9* pDecl) {
-        return this->original->SetVertexDeclaration(pDecl);
-    }
-
-    STDMETHOD(GetVertexDeclaration)(THIS_ IDirect3DVertexDeclaration9** ppDecl) {
-        return this->original->GetVertexDeclaration(ppDecl);
-    }
-
-    STDMETHOD(SetFVF)(THIS_ DWORD FVF) {
-        return this->original->SetFVF(FVF);
-    }
-
-    STDMETHOD(GetFVF)(THIS_ DWORD* pFVF) {
-        return this->original->GetFVF(pFVF);
-    }
-
-    STDMETHOD(CreateVertexShader)(THIS_ CONST DWORD* pFunction, IDirect3DVertexShader9** ppShader) {
-        return this->original->CreateVertexShader(pFunction, ppShader);
-    }
-
-    STDMETHOD(SetVertexShader)(THIS_ IDirect3DVertexShader9* pShader) {
-        return this->original->SetVertexShader(pShader);
-    }
-
-    STDMETHOD(GetVertexShader)(THIS_ IDirect3DVertexShader9** ppShader) {
-        return this->original->GetVertexShader(ppShader);
-    }
-
-    STDMETHOD(SetVertexShaderConstantF)(THIS_ UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount) {
-        return this->original->SetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-    }
-
-    STDMETHOD(GetVertexShaderConstantF)(THIS_ UINT StartRegister, float* pConstantData, UINT Vector4fCount) {
-        return this->original->GetVertexShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-    }
-
-    STDMETHOD(SetVertexShaderConstantI)(THIS_ UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount) {
-        return this->original->SetVertexShaderConstantI(StartRegister, pConstantData, Vector4iCount);
-    }
-
-    STDMETHOD(GetVertexShaderConstantI)(THIS_ UINT StartRegister, int* pConstantData, UINT Vector4iCount) {
-        return this->original->GetVertexShaderConstantI(StartRegister, pConstantData, Vector4iCount);
-    }
-
-    STDMETHOD(SetVertexShaderConstantB)(THIS_ UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount) {
-        return this->original->SetVertexShaderConstantB(StartRegister, pConstantData, BoolCount);
-    }
-
-    STDMETHOD(GetVertexShaderConstantB)(THIS_ UINT StartRegister, BOOL* pConstantData, UINT BoolCount) {
-        return this->original->GetVertexShaderConstantB(StartRegister, pConstantData, BoolCount);
-    }
-
-    STDMETHOD(SetStreamSource)(THIS_ UINT StreamNumber, IDirect3DVertexBuffer9* pStreamData, UINT OffsetInBytes, UINT Stride) {
-        return this->original->SetStreamSource(StreamNumber, pStreamData, OffsetInBytes, Stride);
-    }
-
-    STDMETHOD(GetStreamSource)(THIS_ UINT StreamNumber, IDirect3DVertexBuffer9** ppStreamData, UINT* OffsetInBytes, UINT* pStride) {
-        return this->original->GetStreamSource(StreamNumber, ppStreamData, OffsetInBytes, pStride);
-    }
-
-    STDMETHOD(SetStreamSourceFreq)(THIS_ UINT StreamNumber, UINT Divider) {
-        return this->original->SetStreamSourceFreq(StreamNumber, Divider);
-    }
-
-    STDMETHOD(GetStreamSourceFreq)(THIS_ UINT StreamNumber, UINT* Divider) {
-        return this->original->GetStreamSourceFreq(StreamNumber, Divider);
-    }
-
-    STDMETHOD(SetIndices)(THIS_ IDirect3DIndexBuffer9* pIndexData) {
-        return this->original->SetIndices(pIndexData);
-    }
-
-    STDMETHOD(GetIndices)(THIS_ IDirect3DIndexBuffer9** ppIndexData) {
-        return this->original->GetIndices(ppIndexData);
-    }
-
-    STDMETHOD(CreatePixelShader)(THIS_ CONST DWORD* pFunction, IDirect3DPixelShader9** ppShader) {
-        return this->original->CreatePixelShader(pFunction, ppShader);
-    }
-
-    STDMETHOD(SetPixelShader)(THIS_ IDirect3DPixelShader9* pShader) {
-        return this->original->SetPixelShader(pShader);
-    }
-
-    STDMETHOD(GetPixelShader)(THIS_ IDirect3DPixelShader9** ppShader) {
-        return this->original->GetPixelShader(ppShader);
-    }
-
-    STDMETHOD(SetPixelShaderConstantF)(THIS_ UINT StartRegister, CONST float* pConstantData, UINT Vector4fCount) {
-        return this->original->SetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-    }
-
-    STDMETHOD(GetPixelShaderConstantF)(THIS_ UINT StartRegister, float* pConstantData, UINT Vector4fCount) {
-        return this->original->GetPixelShaderConstantF(StartRegister, pConstantData, Vector4fCount);
-    }
-
-    STDMETHOD(SetPixelShaderConstantI)(THIS_ UINT StartRegister, CONST int* pConstantData, UINT Vector4iCount) {
-        return this->original->SetPixelShaderConstantI(StartRegister, pConstantData, Vector4iCount);
-    }
-
-    STDMETHOD(GetPixelShaderConstantI)(THIS_ UINT StartRegister, int* pConstantData, UINT Vector4iCount) {
-        return this->original->GetPixelShaderConstantI(StartRegister, pConstantData, Vector4iCount);
-    }
-
-    STDMETHOD(SetPixelShaderConstantB)(THIS_ UINT StartRegister, CONST BOOL* pConstantData, UINT  BoolCount) {
-        return this->original->SetPixelShaderConstantB(StartRegister, pConstantData, BoolCount);
-    }
-
-    STDMETHOD(GetPixelShaderConstantB)(THIS_ UINT StartRegister, BOOL* pConstantData, UINT BoolCount) {
-        return this->original->GetPixelShaderConstantB(StartRegister, pConstantData, BoolCount);
-    }
-
-    STDMETHOD(DrawRectPatch)(THIS_ UINT Handle, CONST float* pNumSegs, CONST D3DRECTPATCH_INFO* pRectPatchInfo) {
-        return this->original->DrawRectPatch(Handle, pNumSegs, pRectPatchInfo);
-    }
-
-    STDMETHOD(DrawTriPatch)(THIS_ UINT Handle, CONST float* pNumSegs, CONST D3DTRIPATCH_INFO* pTriPatchInfo) {
-        return this->original->DrawTriPatch(Handle, pNumSegs, pTriPatchInfo);
-    }
-
-    STDMETHOD(DeletePatch)(THIS_ UINT Handle) {
-        return this->original->DeletePatch(Handle);
-    }
-
-    STDMETHOD(CreateQuery)(THIS_ D3DQUERYTYPE Type, IDirect3DQuery9** ppQuery) {
-        return this->original->CreateQuery(Type, ppQuery);
-    }
-
+    STDMETHOD(TestCooperativeLevel)(THIS);
+    STDMETHOD_(UINT, GetAvailableTextureMem)(THIS);
+    STDMETHOD(EvictManagedResources)(THIS);
+    STDMETHOD(GetDirect3D)(THIS_ IDirect3D9 **ppD3D9);
+    STDMETHOD(GetDeviceCaps)(THIS_ D3DCAPS9 *pCaps);
+    STDMETHOD(GetDisplayMode)(THIS_ UINT iSwapChain, D3DDISPLAYMODE *pMode);
+    STDMETHOD(GetCreationParameters)(THIS_ D3DDEVICE_CREATION_PARAMETERS *pParameters);
+    STDMETHOD(SetCursorProperties)(THIS_ UINT XHotSpot, UINT YHotSpot, IDirect3DSurface9 *pCursorBitmap);
+    STDMETHOD_(void, SetCursorPosition)(THIS_ int X, int Y, DWORD Flags);
+    STDMETHOD_(BOOL, ShowCursor)(THIS_ BOOL bShow);
+    STDMETHOD(CreateAdditionalSwapChain)(THIS_ D3DPRESENT_PARAMETERS *pPresentationParameters, IDirect3DSwapChain9 **pSwapChain);
+    STDMETHOD(GetSwapChain)(THIS_ UINT iSwapChain, IDirect3DSwapChain9 **pSwapChain);
+    STDMETHOD_(UINT, GetNumberOfSwapChains)(THIS);
+    STDMETHOD(Reset)(THIS_ D3DPRESENT_PARAMETERS *pPresentationParameters);
+    STDMETHOD(Present)(THIS_ CONST RECT *pSourceRect, CONST RECT *pDestRect, HWND hDestWindowOverride, CONST RGNDATA *pDirtyRegion);
+    STDMETHOD(GetBackBuffer)(THIS_ UINT iSwapChain, UINT iBackBuffer, D3DBACKBUFFER_TYPE Type, IDirect3DSurface9 **ppBackBuffer);
+    STDMETHOD(GetRasterStatus)(THIS_ UINT iSwapChain, D3DRASTER_STATUS *pRasterStatus);
+    STDMETHOD(SetDialogBoxMode)(THIS_ BOOL bEnableDialogs);
+    STDMETHOD_(void, SetGammaRamp)(THIS_ UINT iSwapChain, DWORD Flags, CONST D3DGAMMARAMP *pRamp);
+    STDMETHOD_(void, GetGammaRamp)(THIS_ UINT iSwapChain, D3DGAMMARAMP *pRamp);
+    STDMETHOD(CreateTexture)(THIS_ UINT Width, UINT Height, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DTexture9 **ppTexture, HANDLE *pSharedHandle);
+    STDMETHOD(CreateVolumeTexture)(THIS_ UINT Width, UINT Height, UINT Depth, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DVolumeTexture9 **ppVolumeTexture, HANDLE *pSharedHandle);
+    STDMETHOD(CreateCubeTexture)(THIS_ UINT EdgeLength, UINT Levels, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DCubeTexture9 **ppCubeTexture, HANDLE *pSharedHandle);
+    STDMETHOD(CreateVertexBuffer)(THIS_ UINT Length, DWORD Usage, DWORD FVF, D3DPOOL Pool, IDirect3DVertexBuffer9 **ppVertexBuffer, HANDLE *pSharedHandle);
+    STDMETHOD(CreateIndexBuffer)(THIS_ UINT Length, DWORD Usage, D3DFORMAT Format, D3DPOOL Pool, IDirect3DIndexBuffer9 **ppIndexBuffer, HANDLE *pSharedHandle);
+    STDMETHOD(CreateRenderTarget)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Lockable, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle);
+    STDMETHOD(CreateDepthStencilSurface)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DMULTISAMPLE_TYPE MultiSample, DWORD MultisampleQuality, BOOL Discard, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle);
+    STDMETHOD(UpdateSurface)(THIS_ IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRect, IDirect3DSurface9 *pDestinationSurface, CONST POINT *pDestPoint);
+    STDMETHOD(UpdateTexture)(THIS_ IDirect3DBaseTexture9 *pSourceTexture, IDirect3DBaseTexture9 *pDestinationTexture);
+    STDMETHOD(GetRenderTargetData)(THIS_ IDirect3DSurface9 *pRenderTarget, IDirect3DSurface9 *pDestSurface);
+    STDMETHOD(GetFrontBufferData)(THIS_ UINT iSwapChain, IDirect3DSurface9 *pDestSurface);
+    STDMETHOD(StretchRect)(THIS_ IDirect3DSurface9 *pSourceSurface, CONST RECT *pSourceRect, IDirect3DSurface9 *pDestSurface, CONST RECT *pDestRect, D3DTEXTUREFILTERTYPE Filter);
+    STDMETHOD(ColorFill)(THIS_ IDirect3DSurface9 *pSurface, CONST RECT *pRect, D3DCOLOR color);
+    STDMETHOD(CreateOffscreenPlainSurface)(THIS_ UINT Width, UINT Height, D3DFORMAT Format, D3DPOOL Pool, IDirect3DSurface9 **ppSurface, HANDLE *pSharedHandle);
+    STDMETHOD(SetRenderTarget)(THIS_ DWORD RenderTargetIndex, IDirect3DSurface9 *pRenderTarget);
+    STDMETHOD(GetRenderTarget)(THIS_ DWORD RenderTargetIndex, IDirect3DSurface9 **ppRenderTarget);
+    STDMETHOD(SetDepthStencilSurface)(THIS_ IDirect3DSurface9 *pNewZStencil);
+    STDMETHOD(GetDepthStencilSurface)(THIS_ IDirect3DSurface9 **ppZStencilSurface);
+    STDMETHOD(BeginScene)(THIS);
+    STDMETHOD(EndScene)(THIS);
+    STDMETHOD(Clear)(THIS_ DWORD Count, CONST D3DRECT *pRects, DWORD Flags, D3DCOLOR Color, float Z, DWORD Stencil);
+    STDMETHOD(SetTransform)(THIS_ D3DTRANSFORMSTATETYPE State, CONST D3DMATRIX *pMatrix);
+    STDMETHOD(GetTransform)(THIS_ D3DTRANSFORMSTATETYPE State, D3DMATRIX *pMatrix);
+    STDMETHOD(MultiplyTransform)(THIS_ D3DTRANSFORMSTATETYPE, CONST D3DMATRIX *);
+    STDMETHOD(SetViewport)(THIS_ CONST D3DVIEWPORT9 *pViewport);
+    STDMETHOD(GetViewport)(THIS_ D3DVIEWPORT9 *pViewport);
+    STDMETHOD(SetMaterial)(THIS_ CONST D3DMATERIAL9 *pMaterial);
+    STDMETHOD(GetMaterial)(THIS_ D3DMATERIAL9 *pMaterial);
+    STDMETHOD(SetLight)(THIS_ DWORD Index, CONST D3DLIGHT9 *);
+    STDMETHOD(GetLight)(THIS_ DWORD Index, D3DLIGHT9 *);
+    STDMETHOD(LightEnable)(THIS_ DWORD Index, BOOL Enable);
+    STDMETHOD(GetLightEnable)(THIS_ DWORD Index, BOOL *pEnable);
+    STDMETHOD(SetClipPlane)(THIS_ DWORD Index, CONST float *pPlane);
+    STDMETHOD(GetClipPlane)(THIS_ DWORD Index, float *pPlane);
+    STDMETHOD(SetRenderState)(THIS_ D3DRENDERSTATETYPE State, DWORD Value);
+    STDMETHOD(GetRenderState)(THIS_ D3DRENDERSTATETYPE State, DWORD *pValue);
+    STDMETHOD(CreateStateBlock)(THIS_ D3DSTATEBLOCKTYPE Type, IDirect3DStateBlock9 **ppSB);
+    STDMETHOD(BeginStateBlock)(THIS);
+    STDMETHOD(EndStateBlock)(THIS_ IDirect3DStateBlock9 **ppSB);
+    STDMETHOD(SetClipStatus)(THIS_ CONST D3DCLIPSTATUS9 *pClipStatus);
+    STDMETHOD(GetClipStatus)(THIS_ D3DCLIPSTATUS9 *pClipStatus);
+    STDMETHOD(GetTexture)(THIS_ DWORD Stage, IDirect3DBaseTexture9 **ppTexture);
+    STDMETHOD(SetTexture)(THIS_ DWORD Stage, IDirect3DBaseTexture9 *pTexture);
+    STDMETHOD(GetTextureStageState)(THIS_ DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD *pValue);
+    STDMETHOD(SetTextureStageState)(THIS_ DWORD Stage, D3DTEXTURESTAGESTATETYPE Type, DWORD Value);
+    STDMETHOD(GetSamplerState)(THIS_ DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD *pValue);
+    STDMETHOD(SetSamplerState)(THIS_ DWORD Sampler, D3DSAMPLERSTATETYPE Type, DWORD Value);
+    STDMETHOD(ValidateDevice)(THIS_ DWORD *pNumPasses);
+    STDMETHOD(SetPaletteEntries)(THIS_ UINT PaletteNumber, CONST PALETTEENTRY *pEntries);
+    STDMETHOD(GetPaletteEntries)(THIS_ UINT PaletteNumber, PALETTEENTRY *pEntries);
+    STDMETHOD(SetCurrentTexturePalette)(THIS_ UINT PaletteNumber);
+    STDMETHOD(GetCurrentTexturePalette)(THIS_ UINT *PaletteNumber);
+    STDMETHOD(SetScissorRect)(THIS_ CONST RECT *pRect);
+    STDMETHOD(GetScissorRect)(THIS_ RECT *pRect);
+    STDMETHOD(SetSoftwareVertexProcessing)(THIS_ BOOL bSoftware);
+    STDMETHOD_(BOOL, GetSoftwareVertexProcessing)(THIS);
+    STDMETHOD(SetNPatchMode)(THIS_ float nSegments);
+    STDMETHOD_(float, GetNPatchMode)(THIS);
+    STDMETHOD(DrawPrimitive)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT StartVertex, UINT PrimitiveCount);
+    STDMETHOD(DrawIndexedPrimitive)(THIS_ D3DPRIMITIVETYPE, INT BaseVertexIndex, UINT MinVertexIndex, UINT NumVertices, UINT startIndex, UINT primCount);
+    STDMETHOD(DrawPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT PrimitiveCount, CONST void *pVertexStreamZeroData, UINT VertexStreamZeroStride);
+    STDMETHOD(DrawIndexedPrimitiveUP)(THIS_ D3DPRIMITIVETYPE PrimitiveType, UINT MinVertexIndex, UINT NumVertices, UINT PrimitiveCount, CONST void *pIndexData, D3DFORMAT IndexDataFormat, CONST void *pVertexStreamZeroData, UINT VertexStreamZeroStride);
+    STDMETHOD(ProcessVertices)(THIS_ UINT SrcStartIndex, UINT DestIndex, UINT VertexCount, IDirect3DVertexBuffer9 *pDestBuffer, IDirect3DVertexDeclaration9 *pVertexDecl, DWORD Flags);
+    STDMETHOD(CreateVertexDeclaration)(THIS_ CONST D3DVERTEXELEMENT9 *pVertexElements, IDirect3DVertexDeclaration9 **ppDecl);
+    STDMETHOD(SetVertexDeclaration)(THIS_ IDirect3DVertexDeclaration9 *pDecl);
+    STDMETHOD(GetVertexDeclaration)(THIS_ IDirect3DVertexDeclaration9 **ppDecl);
+    STDMETHOD(SetFVF)(THIS_ DWORD FVF);
+    STDMETHOD(GetFVF)(THIS_ DWORD *pFVF);
+    STDMETHOD(CreateVertexShader)(THIS_ CONST DWORD *pFunction, IDirect3DVertexShader9 **ppShader);
+    STDMETHOD(SetVertexShader)(THIS_ IDirect3DVertexShader9 *pShader);
+    STDMETHOD(GetVertexShader)(THIS_ IDirect3DVertexShader9 **ppShader);
+    STDMETHOD(SetVertexShaderConstantF)(THIS_ UINT StartRegister, CONST float *pConstantData, UINT Vector4fCount);
+    STDMETHOD(GetVertexShaderConstantF)(THIS_ UINT StartRegister, float *pConstantData, UINT Vector4fCount);
+    STDMETHOD(SetVertexShaderConstantI)(THIS_ UINT StartRegister, CONST int *pConstantData, UINT Vector4iCount);
+    STDMETHOD(GetVertexShaderConstantI)(THIS_ UINT StartRegister, int *pConstantData, UINT Vector4iCount);
+    STDMETHOD(SetVertexShaderConstantB)(THIS_ UINT StartRegister, CONST BOOL *pConstantData, UINT  BoolCount);
+    STDMETHOD(GetVertexShaderConstantB)(THIS_ UINT StartRegister, BOOL *pConstantData, UINT BoolCount);
+    STDMETHOD(SetStreamSource)(THIS_ UINT StreamNumber, IDirect3DVertexBuffer9 *pStreamData, UINT OffsetInBytes, UINT Stride);
+    STDMETHOD(GetStreamSource)(THIS_ UINT StreamNumber, IDirect3DVertexBuffer9 **ppStreamData, UINT *OffsetInBytes, UINT *pStride);
+    STDMETHOD(SetStreamSourceFreq)(THIS_ UINT StreamNumber, UINT Divider);
+    STDMETHOD(GetStreamSourceFreq)(THIS_ UINT StreamNumber, UINT *Divider);
+    STDMETHOD(SetIndices)(THIS_ IDirect3DIndexBuffer9 *pIndexData);
+    STDMETHOD(GetIndices)(THIS_ IDirect3DIndexBuffer9 **ppIndexData);
+    STDMETHOD(CreatePixelShader)(THIS_ CONST DWORD *pFunction, IDirect3DPixelShader9 **ppShader);
+    STDMETHOD(SetPixelShader)(THIS_ IDirect3DPixelShader9 *pShader);
+    STDMETHOD(GetPixelShader)(THIS_ IDirect3DPixelShader9 **ppShader);
+    STDMETHOD(SetPixelShaderConstantF)(THIS_ UINT StartRegister, CONST float *pConstantData, UINT Vector4fCount);
+    STDMETHOD(GetPixelShaderConstantF)(THIS_ UINT StartRegister, float *pConstantData, UINT Vector4fCount);
+    STDMETHOD(SetPixelShaderConstantI)(THIS_ UINT StartRegister, CONST int *pConstantData, UINT Vector4iCount);
+    STDMETHOD(GetPixelShaderConstantI)(THIS_ UINT StartRegister, int *pConstantData, UINT Vector4iCount);
+    STDMETHOD(SetPixelShaderConstantB)(THIS_ UINT StartRegister, CONST BOOL *pConstantData, UINT  BoolCount);
+    STDMETHOD(GetPixelShaderConstantB)(THIS_ UINT StartRegister, BOOL *pConstantData, UINT BoolCount);
+    STDMETHOD(DrawRectPatch)(THIS_ UINT Handle, CONST float *pNumSegs, CONST D3DRECTPATCH_INFO *pRectPatchInfo);
+    STDMETHOD(DrawTriPatch)(THIS_ UINT Handle, CONST float *pNumSegs, CONST D3DTRIPATCH_INFO *pTriPatchInfo);
+    STDMETHOD(DeletePatch)(THIS_ UINT Handle);
+    STDMETHOD(CreateQuery)(THIS_ D3DQUERYTYPE Type, IDirect3DQuery9 **ppQuery);
 
     /*** Helper information ***/
     D3DDEVICE_CREATION_PARAMETERS CreationParameters;
@@ -526,4 +167,3 @@ public:
     RECT ScissorRect;
     BOOL DialogBoxMode;
 };
-

--- a/src/OniPatch/OniHook.cpp
+++ b/src/OniPatch/OniHook.cpp
@@ -1,0 +1,100 @@
+#include "pch.h"
+#include "OniHook.h"
+
+CreateWindowExWType OniHook::TrueCreateWindowExW = nullptr;
+Direct3DCreate9Type OniHook::TrueDirect3DCreate9 = nullptr;
+OniHook *OniHook::instance = nullptr;
+
+HWND WINAPI OniHook::MyCreateWindowExW(
+    DWORD dwExStyle,
+    _In_opt_ LPCWSTR   lpClassName,
+    _In_opt_ LPCWSTR   lpWindowName,
+    _In_     DWORD     dwStyle,
+    _In_     int       X,
+    _In_     int       Y,
+    _In_     int       nWidth,
+    _In_     int       nHeight,
+    _In_opt_ HWND      hWndParent,
+    _In_opt_ HMENU     hMenu,
+    _In_opt_ HINSTANCE hInstance,
+    _In_opt_ LPVOID    lpParam
+)
+{
+    TraceFunc();
+
+    if (lpWindowName == NULL)
+        exit(302);
+
+    TraceParam("Window name", lpWindowName);
+
+    if (!wcscmp(lpWindowName, L"oni3")) {
+        TraceMsg("Oni window found");
+
+        const DWORD borderLessStyle = WS_POPUP | WS_VISIBLE | WS_SYSMENU;
+        const DWORD resizableStyle = WS_TILEDWINDOW;
+
+        X = CW_USEDEFAULT;
+        Y = CW_USEDEFAULT;
+
+        // TODO: Read from config
+        nWidth = 1920;
+        nHeight = 1080;
+        dwExStyle = WS_EX_APPWINDOW;
+        dwStyle = resizableStyle;
+    }
+
+    HWND result = TrueCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
+
+    if (result == NULL) {
+        DWORD errorCode = GetLastError();
+        std::cerr << "CreateWindowExW failed with error code " << errorCode << std::endl;
+    }
+
+    return result;
+}
+
+IDirect3D9 *WINAPI OniHook::MyDirect3DCreate9(UINT SDKVersion)
+{
+    TraceFunc();
+    IDirect3D9 *d3d9 = TrueDirect3DCreate9(SDKVersion);
+
+    return new MyIDirect3D9(d3d9);
+}
+
+void OniHook::LoadEntryPoints()
+{
+    TraceFunc();
+
+    TrueCreateWindowExW = reinterpret_cast<CreateWindowExWType>(Utils::LoadProcAddress("user32", "CreateWindowExW"));
+    TrueDirect3DCreate9 = reinterpret_cast<Direct3DCreate9Type>(Utils::LoadProcAddress("d3d9", "Direct3DCreate9"));
+}
+
+OniHook *OniHook::GetInstance()
+{
+    if (OniHook::instance == nullptr) {
+        OniHook::instance = new OniHook();
+    }
+
+    return OniHook::instance;
+}
+
+void OniHook::Hook()
+{
+    TraceFunc();
+
+    LoadEntryPoints();
+
+    DetourTransactionBegin();
+    DetourUpdateThread(GetCurrentThread());
+
+    DetourAttach((PVOID *)&TrueDirect3DCreate9, MyDirect3DCreate9);
+    DetourAttach((PVOID *)&TrueCreateWindowExW, MyCreateWindowExW);
+
+    if (DetourTransactionCommit() != NO_ERROR) {
+        std::cerr << "Detour failed";
+    }
+}
+
+void OniHook::UnHook()
+{
+}

--- a/src/OniPatch/OniHook.h
+++ b/src/OniPatch/OniHook.h
@@ -1,13 +1,12 @@
 #pragma once
 
-#include <detours.h>
-#include "Trace.h"
-#include <d3d9helper.h>
+#include "pch.h"
 #include "Utils.h"
+#include "Trace.h"
 #include "MyIDirect3D9.h"
 
 // Type
-typedef HWND(WINAPI* CreateWindowExWType) (
+typedef HWND(WINAPI *CreateWindowExWType) (
 	_In_ DWORD dwExStyle,
 	_In_opt_ LPCWSTR lpClassName,
 	_In_opt_ LPCWSTR lpWindowName,
@@ -21,111 +20,21 @@ typedef HWND(WINAPI* CreateWindowExWType) (
 	_In_opt_ HINSTANCE hInstance,
 	_In_opt_ LPVOID lpParam);
 
-typedef IDirect3D9* (WINAPI* Direct3DCreate9Type) (UINT SDKVersion);
+typedef IDirect3D9 *(WINAPI *Direct3DCreate9Type) (UINT SDKVersion);
 
 class OniHook
 {
 private:
-	static OniHook* instance;
+	static OniHook *instance;
 public:
 	static CreateWindowExWType TrueCreateWindowExW;
 	static Direct3DCreate9Type TrueDirect3DCreate9;
 
 	// Hooks
-
-	static HWND WINAPI MyCreateWindowExW(
-		DWORD dwExStyle,
-		_In_opt_ LPCWSTR lpClassName,
-		_In_opt_ LPCWSTR lpWindowName,
-		_In_ DWORD dwStyle,
-		_In_ int X,
-		_In_ int Y,
-		_In_ int nWidth,
-		_In_ int nHeight,
-		_In_opt_ HWND hWndParent,
-		_In_opt_ HMENU hMenu,
-		_In_opt_ HINSTANCE hInstance,
-		_In_opt_ LPVOID lpParam)
-	{
-		TraceFunc();
-
-		std::string windowName;
-
-		if (lpWindowName != NULL) {
-			windowName = Utils::WStringToString(lpWindowName);
-		}
-
-		TraceParam("Window name", windowName);
-
-		if (windowName == "oni3") {
-			TraceMsg("Oni window found");
-
-			const DWORD borderLessStyle = WS_POPUP | WS_VISIBLE | WS_SYSMENU;
-			const DWORD resizableStyle = WS_TILEDWINDOW;
-
-			X = CW_USEDEFAULT;
-			Y = CW_USEDEFAULT;
-
-			// TODO: Read from config
-			nWidth = 1920;
-			nHeight = 1080;
-			dwExStyle = WS_EX_APPWINDOW;
-			dwStyle = resizableStyle;
-		}
-
-		HWND result = TrueCreateWindowExW(dwExStyle, lpClassName, lpWindowName, dwStyle, X, Y, nWidth, nHeight, hWndParent, hMenu, hInstance, lpParam);
-
-		if (result == NULL) {
-			DWORD errorCode = GetLastError();
-			std::cerr << "CreateWindowExW failed with error code " << errorCode << std::endl;
-		}
-
-		return result;
-	}
-
-	static IDirect3D9* WINAPI MyDirect3DCreate9(
-		UINT SDKVersion
-	) {
-		TraceFunc();
-		IDirect3D9* d3d9 = TrueDirect3DCreate9(SDKVersion);
-
-		return new MyIDirect3D9(d3d9);
-	}
-
-	void LoadEntryPoints() {
-		TraceFunc();
-
-		TrueCreateWindowExW = reinterpret_cast<CreateWindowExWType>(Utils::LoadProcAddress("user32", "CreateWindowExW"));
-		TrueDirect3DCreate9 = reinterpret_cast<Direct3DCreate9Type>(Utils::LoadProcAddress("d3d9", "Direct3DCreate9"));
-	}
-
-	static OniHook* GetInstance() {
-		if (OniHook::instance == nullptr) {
-			OniHook::instance = new OniHook();
-		}
-
-		return OniHook::instance;
-	}
-
-	void Hook() {
-		TraceFunc();
-
-		LoadEntryPoints();
-
-		DetourTransactionBegin();
-		DetourUpdateThread(GetCurrentThread());
-
-		DetourAttach((PVOID*)&TrueDirect3DCreate9, MyDirect3DCreate9);
-		DetourAttach((PVOID*)&TrueCreateWindowExW, MyCreateWindowExW);
-
-		if (DetourTransactionCommit() != NO_ERROR) {
-			std::cerr << "Detour failed";
-		}
-	}
-
-	void UnHook() {	}
+	static HWND WINAPI MyCreateWindowExW(DWORD dwExStyle, _In_opt_ LPCWSTR lpClassName, _In_opt_ LPCWSTR lpWindowName, _In_ DWORD dwStyle, _In_ int X, _In_ int Y, _In_ int nWidth, _In_ int nHeight, _In_opt_ HWND hWndParent, _In_opt_ HMENU hMenu, _In_opt_ HINSTANCE hInstance, _In_opt_ LPVOID lpParam);
+	static IDirect3D9 *WINAPI MyDirect3DCreate9(UINT SDKVersion);
+	void LoadEntryPoints();
+	static OniHook *GetInstance();
+	void Hook();
+	void UnHook();
 };
-
-CreateWindowExWType OniHook::TrueCreateWindowExW = nullptr;
-Direct3DCreate9Type OniHook::TrueDirect3DCreate9 = nullptr;
-OniHook* OniHook::instance = nullptr;

--- a/src/OniPatch/OniPatch.vcxproj
+++ b/src/OniPatch/OniPatch.vcxproj
@@ -152,6 +152,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClInclude Include="dllmain.h" />
     <ClInclude Include="framework.h" />
     <ClInclude Include="MyIDirect3DDevice9.h" />
     <ClInclude Include="OniHook.h" />
@@ -162,12 +163,17 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="dllmain.cpp" />
+    <ClCompile Include="MyIDirect3D9.cpp" />
+    <ClCompile Include="MyIDirect3DDevice9.cpp" />
+    <ClCompile Include="OniHook.cpp" />
     <ClCompile Include="pch.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Create</PrecompiledHeader>
     </ClCompile>
+    <ClCompile Include="Trace.cpp" />
+    <ClCompile Include="Utils.cpp" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/src/OniPatch/OniPatch.vcxproj.filters
+++ b/src/OniPatch/OniPatch.vcxproj.filters
@@ -1,28 +1,69 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="dllmain.cpp" />
-    <ClCompile Include="pch.cpp" />
+    <ClCompile Include="dllmain.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
+    <ClCompile Include="pch.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
+    <ClCompile Include="MyIDirect3D9.cpp">
+      <Filter>Fichiers sources\DirectX</Filter>
+    </ClCompile>
+    <ClCompile Include="MyIDirect3DDevice9.cpp">
+      <Filter>Fichiers sources\DirectX</Filter>
+    </ClCompile>
+    <ClCompile Include="OniHook.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
+    <ClCompile Include="Utils.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
+    <ClCompile Include="Trace.cpp">
+      <Filter>Fichiers sources</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="framework.h" />
-    <ClInclude Include="OniHook.h" />
-    <ClInclude Include="Trace.h" />
-    <ClInclude Include="pch.h" />
-    <ClInclude Include="Utils.h" />
     <ClInclude Include="MyIDirect3D9.h">
-      <Filter>DirectX</Filter>
+      <Filter>Fichiers d%27en-tête\DirectX</Filter>
     </ClInclude>
     <ClInclude Include="MyIDirect3DDevice9.h">
-      <Filter>DirectX</Filter>
+      <Filter>Fichiers d%27en-tête\DirectX</Filter>
+    </ClInclude>
+    <ClInclude Include="framework.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="OniHook.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="pch.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="Utils.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="Trace.h">
+      <Filter>Fichiers d%27en-tête</Filter>
+    </ClInclude>
+    <ClInclude Include="dllmain.h">
+      <Filter>Fichiers d%27en-tête</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Filter Include="DirectX">
+    <Filter Include="Fichiers d%27en-tête">
+      <UniqueIdentifier>{017dfc0d-c75c-4057-93a9-bc67fd6ce130}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Fichiers d%27en-tête\DirectX">
       <UniqueIdentifier>{d6c54930-06ad-4ce2-9e57-fbf345e71043}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Fichiers sources">
+      <UniqueIdentifier>{35eba429-1735-492d-a41d-d983b6e6d85e}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Fichiers sources\DirectX">
+      <UniqueIdentifier>{b9b462a1-efd5-4cf6-b6ea-57b95a034798}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
 </Project>

--- a/src/OniPatch/Trace.cpp
+++ b/src/OniPatch/Trace.cpp
@@ -1,0 +1,20 @@
+#include "pch.h"
+#include "Trace.h"
+
+
+Trace::Trace(const std::string &functionName)
+{
+	this->functionName = functionName;
+
+	std::cout << "[Enter Function] " << this->functionName << std::endl;
+}
+
+void Trace::TraceMessage(const std::string message)
+{
+	std::cout << "\t" << message << std::endl;
+}
+
+Trace::~Trace()
+{
+	std::cout << "[Exit Function] " << this->functionName << std::endl;
+}

--- a/src/OniPatch/Trace.h
+++ b/src/OniPatch/Trace.h
@@ -1,32 +1,29 @@
 #pragma once
-#include <iostream>
 
+#ifdef _DEBUG
 #define TraceFunc() Trace __log = Trace(__FUNCTION__)
 #define TraceParam(ParamName, ParamValue) __log.TraceParameter(ParamName, ParamValue)
 #define TraceMsg(Message) __log.TraceMessage(Message)
+#else
+#define TraceFunc()
+#define TraceParam(ParamName, ParamValue)
+#define TraceMsg(Message)
+#endif
 
 class Trace
 {
 private:
-	std::string functionName;
+    std::string functionName;
 
 public:
-	Trace(const std::string& functionName) {
-		this->functionName = functionName;
+    Trace(const std::string &functionName);
 
-		std::cout << "[Enter Function] " << this->functionName << std::endl;
-	}
+    template <typename T>
+    void TraceParameter(const std::string &parameterName, const T &parameter)
+    {
+        std::cout << "\t" << parameterName << ": " << parameter << std::endl;
+    }
 
-	template <typename T>
-	void TraceParameter(const std::string& parameterName, const T& parameter) {
-		std::cout << "\t" << parameterName << ": " << parameter << std::endl;
-	}
-
-	void TraceMessage(const std::string message) {
-		std::cout << "\t" << message << std::endl;
-	}
-
-	~Trace() {
-		std::cout << "[Exit Function] " << this->functionName << std::endl;
-	}
+    void TraceMessage(const std::string message);
+    ~Trace();
 };

--- a/src/OniPatch/Utils.cpp
+++ b/src/OniPatch/Utils.cpp
@@ -1,0 +1,35 @@
+#include "pch.h"
+#include "Utils.h"
+
+void Utils::EnableConsole() {
+	if (AllocConsole()) {
+		FILE *fDummy;
+		freopen_s(&fDummy, "CONIN$", "r", stdin);
+		freopen_s(&fDummy, "CONOUT$", "w", stderr);
+		freopen_s(&fDummy, "CONOUT$", "w", stdout);
+	}
+}
+
+FARPROC Utils::LoadProcAddress(LPCSTR moduleName, LPCSTR procName) {
+	std::cout << "Loading procedure " << procName << " from module " << moduleName << std::endl;
+
+	HMODULE hModule = GetModuleHandleA(moduleName);
+
+	if (hModule == NULL) {
+		std::cout << moduleName << " not yet loaded. Loading..." << std::endl;
+		hModule = LoadLibraryA(moduleName);
+		if (hModule == NULL) {
+			std::cerr << "Module " << moduleName << " not found" << std::endl;
+			return NULL;
+		}
+	}
+
+	FARPROC procAddr = GetProcAddress(hModule, procName);
+
+	if (procAddr == NULL) {
+		std::cerr << "Procedure " << procName << " not found" << std::endl;
+		return NULL;
+	}
+
+	return procAddr;
+}

--- a/src/OniPatch/Utils.h
+++ b/src/OniPatch/Utils.h
@@ -1,47 +1,14 @@
 #pragma once
-#include <windows.h>
-#include <iostream>
+
+#ifdef _DEBUG
+#define ENABLECONSOLE() Utils::EnableConsole()
+#else
+#define ENABLECONSOLE()
+#endif
 
 class Utils
 {
-public :
-	static void EnableConsole() {
-		if (AllocConsole()) {
-			FILE* fDummy;
-			freopen_s(&fDummy, "CONIN$", "r", stdin);
-			freopen_s(&fDummy, "CONOUT$", "w", stderr);
-			freopen_s(&fDummy, "CONOUT$", "w", stdout);
-		}
-	}
-
-	static std::string WStringToString(const std::wstring& s)
-	{
-		std::string temp(s.length(), ' ');
-		std::copy(s.begin(), s.end(), temp.begin());
-		return temp;
-	}
-
-	static FARPROC LoadProcAddress(LPCSTR moduleName, LPCSTR procName) {
-		std::cout << "Loading procedure " << procName << " from module " << moduleName << std::endl;
-
-		HMODULE hModule = GetModuleHandleA(moduleName);
-
-		if (hModule == NULL) {
-			std::cout << moduleName << " not yet loaded. Loading..." << std::endl;
-			hModule = LoadLibraryA(moduleName);
-			if (hModule == NULL) {
-				std::cerr << "Module " << moduleName << " not found" << std::endl;
-				return NULL;
-			}
-		}
-
-		FARPROC procAddr = GetProcAddress(hModule, procName);
-
-		if (procAddr == NULL) {
-			std::cerr << "Procedure " << procName << " not found" << std::endl;
-			return NULL;
-		}
-
-		return procAddr;
-	}
+public:
+	static void EnableConsole();
+	static FARPROC LoadProcAddress(LPCSTR moduleName, LPCSTR procName);
 };

--- a/src/OniPatch/dllmain.cpp
+++ b/src/OniPatch/dllmain.cpp
@@ -1,30 +1,23 @@
 // dllmain.cpp : Définit le point d'entrée de l'application DLL.
 #include "pch.h"
-
-#include <iostream>
-#include <detours.h>
-#include "Trace.h"
-#include "Utils.h"
-#include <d3d9helper.h>
-#include "MyIDirect3D9.h"
-#include "OniHook.h"
+#include "dllmain.h"
 
 BOOL APIENTRY DllMain(HMODULE hModule,
-	DWORD  ul_reason_for_call,
-	LPVOID lpReserved
+    DWORD  ul_reason_for_call,
+    LPVOID lpReserved
 )
 {
-	if (ul_reason_for_call == DLL_PROCESS_ATTACH)
-	{
-		DisableThreadLibraryCalls(hModule);
+    if (ul_reason_for_call == DLL_PROCESS_ATTACH)
+    {
+        DisableThreadLibraryCalls(hModule);
 
-		// TODO: Enable/Disable from config
-		Utils::EnableConsole();
+        // TODO: Enable/Disable from config
+        ENABLECONSOLE();
 
-		auto hook = OniHook::GetInstance();
-		hook->Hook();
-	}
+        auto hook = OniHook::GetInstance();
+        hook->Hook();
+    }
 
-	return TRUE;
+    return TRUE;
 }
 

--- a/src/OniPatch/dllmain.h
+++ b/src/OniPatch/dllmain.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "pch.h";
+#include "Utils.h"
+#include "Onihook.h"
+
+BOOL APIENTRY DllMain(HMODULE hModule, DWORD  ul_reason_for_call, LPVOID lpReserved);

--- a/src/OniPatch/framework.h
+++ b/src/OniPatch/framework.h
@@ -3,3 +3,7 @@
 #define WIN32_LEAN_AND_MEAN             // Exclure les en-têtes Windows rarement utilisés
 // Fichiers d'en-tête Windows
 #include <windows.h>
+#include <iostream>
+#include <detours.h>
+#include <d3d9helper.h>
+#include <wchar.h>


### PR DESCRIPTION
Fix bug on ``MyIDirect3D9::GetAdaptatorModeCount()`` that was using and returning ``original->GetAdapterCount();``
Refactoring the code so that the functions are separated from the header files in their respective ``.cpp`` files.
Disable console and trace on release builds.